### PR TITLE
Add homepage to gemspec (points to github src)

### DIFF
--- a/capistrano-thin.gemspec
+++ b/capistrano-thin.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["a.lepore@freegoweb.it"]
   spec.summary       = %q{Thin support for Capistrano 3.x}
   spec.description   = %q{Thin support for Capistrano 3.x}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/freego/capistrano-thin"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Adds a link in the gemspec to the freego source. This should save people in the future from trying to track down alepore's capistrano-thin gem (and should provide a homepage link on rubygems.org for the next version).
