### PR TITLE
Custom config file

### DIFF
--- a/lib/capistrano/tasks/thin.cap
+++ b/lib/capistrano/tasks/thin.cap
@@ -5,7 +5,8 @@ namespace :deploy do
     task command do
       on roles(:app), in: :sequence, wait: 5 do
         within current_path do
-          execute :bundle, "exec thin #{command} -C config/thin/#{fetch(:stage)}.yml"
+          config_file = fetch(:thin_config_path, "config/thin/#{fetch(:stage)}.yml")
+          execute :bundle, "exec thin #{command} -C #{config_file}"
         end
       end
     end


### PR DESCRIPTION
This pull request introduces ability to set up custom config file by setting Capistrano variable

```set :thin_config_path, -> { "#{shared_path}/config/thin.yml" }```