### PR TITLE
Rename namespace to :thin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,20 +3,32 @@
 Simple Thin specific tasks for Capistrano 3.x, implements the following tasks:
 
 ```
+thin:restart
+thin:start
+thin:stop
+
+# DEPRECATED - will be removed later
 deploy:restart
 deploy:start
 deploy:stop
 ```
 
-Note: A valid Thin config file is expected under
+## Configuration
+
+A valid Thin config file is expected under
 `config/thin/(production|staging|whatever).yml`.
+but you can also specify custom config file using `set` e.g.
+
+```ruby
+set :thin_config_path, -> { "#{shared_path}/config/thin.yml" }
+```
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'capistrano-thin', '~> 1.1.0'
+gem 'capistrano-thin', '~> 1.2.0'
 ```
 
 If you use RVM on the server you should also add:

--- a/capistrano-thin.gemspec
+++ b/capistrano-thin.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "capistrano-thin"
-  spec.version       = "1.1.1"
+  spec.version       = "1.2.0"
   spec.authors       = ["Alessandro Lepore"]
   spec.email         = ["a.lepore@freegoweb.it"]
   spec.summary       = %q{Thin support for Capistrano 3.x}

--- a/lib/capistrano/tasks/deploy.cap
+++ b/lib/capistrano/tasks/deploy.cap
@@ -1,0 +1,10 @@
+namespace :deploy do
+  commands = %w(start stop restart)
+
+  commands.each do |command|
+    task command do
+      puts 'DEPRECATED - Please use thin:' + command.to_s
+      invoke 'thin:' + command.to_s
+    end
+  end
+end

--- a/lib/capistrano/tasks/thin.cap
+++ b/lib/capistrano/tasks/thin.cap
@@ -1,4 +1,4 @@
-namespace :deploy do
+namespace :thin do
   commands = %w(start stop restart)
 
   commands.each do |command|

--- a/lib/capistrano/thin.rb
+++ b/lib/capistrano/thin.rb
@@ -1,1 +1,2 @@
 load File.expand_path('../tasks/thin.cap', __FILE__)
+load File.expand_path('../tasks/deploy.cap', __FILE__)


### PR DESCRIPTION
Things done

- changed :deploy to :thin
- :deploy is still supported with deprecation message
- Update Readme 
- Update gemspec + bump version to 1.2